### PR TITLE
Fix type in WPILib.h include.

### DIFF
--- a/roborio/c++/navx_frc_cpp/src/SerialIO.h
+++ b/roborio/c++/navx_frc_cpp/src/SerialIO.h
@@ -8,7 +8,7 @@
 #ifndef SRC_SERIALIO_H_
 #define SRC_SERIALIO_H_
 
-#include "WPILIb.h"
+#include "WPILib.h"
 #include "IIOProvider.h"
 #include <stdint.h>
 #include <AHRSProtocol.h>


### PR DESCRIPTION
This fixes a compile error on case-sensitive file systems.